### PR TITLE
add debug warning when cleanup thread is not finished

### DIFF
--- a/common/include/kernel/Scheduler.h
+++ b/common/include/kernel/Scheduler.h
@@ -40,6 +40,7 @@ class Scheduler
     friend class CleanupThread;
 
     void cleanupDeadThreads();
+    void checkCleanupThreadState();
 
   private:
     Scheduler();

--- a/common/include/kernel/Scheduler.h
+++ b/common/include/kernel/Scheduler.h
@@ -40,7 +40,6 @@ class Scheduler
     friend class CleanupThread;
 
     void cleanupDeadThreads();
-    void checkCleanupThreadState();
 
   private:
     Scheduler();
@@ -66,6 +65,8 @@ class Scheduler
     size_t block_scheduling_;
 
     size_t ticks_;
+
+    size_t unfinished_cleanup_counter_;
 
     IdleThread idle_thread_;
     CleanupThread cleanup_thread_;


### PR DESCRIPTION
Introduced a debug warning in the scheduler to log when the cleanup thread
has not finished cleaning up all threads marked for destruction before it
is descheduled. This ensures that any unfinished cleanup work is flagged,
helping to identify potential issues with thread management or incomplete 
cleanup processes in the system.
