### PR TITLE
Convenience changes for `clangd` users 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ sweb.kdev*
 .cdtproject
 .cdtbuild
 .idea
+.cache
+.clangd
 cmake-build-*/*
 
 # OS-specific files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Include custom CMake modules from the cmake/ subdirectory
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)


### PR DESCRIPTION
I use neovim with Mason and `clangd` as my goto language server setup for my C/C++ programming. Clangd requires a `compile_commands.json` to find the libraries and include headers and to show them correctly in the editor. Clangd can also be configured on a per project base with a `.clangd` file and caches indexes in a `.cache` directory.

This pr lets cmake generate the `compile_commands.json` file by default and hides `.cache` and `.clangd` from git via gitignore.