### PR TITLE
ARM and SWEBDBG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ add_custom_target (kernel_to_image
 
 #Custom Command: Outputs kernel_image
 #Executes the linker command after all libraries where build successfully
-if("${ARCH}" MATCHES "armv8")
+if("${ARCH}" MATCHES "arm")
 #For armv8 we need to execute the final linking step twice because after the first time
 #The debug info gets extracted and linked in at the second link step
 add_custom_target (kernel_image

--- a/arch/arm/common/include/ArchMemory.h
+++ b/arch/arm/common/include/ArchMemory.h
@@ -3,6 +3,7 @@
 #include "types.h"
 #include "paging-definitions.h"
 #include "uvector.h"
+#include "offsets.h"
 
 /**
  *
@@ -56,7 +57,7 @@ public:
  */
   static pointer getIdentAddressOfPPN(uint32 ppn, uint32 page_size=PAGE_SIZE)
   {
-    return 0xC0000000U + (ppn * page_size);
+    return IDENT_MAPPING_START | (ppn * page_size);
   }
 
 /**

--- a/arch/arm/common/include/offsets.h
+++ b/arch/arm/common/include/offsets.h
@@ -32,6 +32,11 @@
 #define VIRTUAL_TO_PHYSICAL_BOOT(x) ((x) - PHYSICAL_TO_VIRTUAL_OFFSET)
 
 /**
+ * The start of the ident mapping
+ */
+#define IDENT_MAPPING_START 0xC0000000U
+
+/**
  * Only addresses below 2gig virtual belong to the user space
  */
 #define USER_BREAK 0x80000000

--- a/arch/arm/common/include/paging-definitions.h
+++ b/arch/arm/common/include/paging-definitions.h
@@ -8,8 +8,6 @@
 #define PAGE_SIZE 4096
 #define PAGE_INDEX_OFFSET_BITS 12
 
-#define PHYSICAL_OFFSET     0xC0000000
-
 
 // Constants for page fault handling
 #define ERROR_MASK            0x00000007

--- a/arch/arm/common/source/ArchCommon.cpp
+++ b/arch/arm/common/source/ArchCommon.cpp
@@ -24,7 +24,7 @@ pointer ArchCommon::getFreeKernelMemoryStart()
 
 pointer ArchCommon::getFreeKernelMemoryEnd()
 {
-   return (pointer)getModuleEndAddress(0);
+   return (pointer)&kernel_end_address;
 }
 
 
@@ -35,17 +35,17 @@ uint32 ArchCommon::haveVESAConsole(uint32 is_paging_set_up __attribute__((unused
 
 uint32 ArchCommon::getNumModules(uint32 is_paging_set_up __attribute__((unused)))
 {
-  return 1;
+  return 0;
 }
 
-uint32 ArchCommon::getModuleStartAddress(uint32 num __attribute__((unused)), uint32 is_paging_set_up __attribute__((unused)))
+uint32 ArchCommon::getModuleStartAddress(uint32 num __attribute__((unused)))
 {
-  return 0x80000000U;
+  assert(false);
 }
 
-uint32 ArchCommon::getModuleEndAddress(uint32 num __attribute__((unused)), uint32 is_paging_set_up __attribute__((unused)))
+uint32 ArchCommon::getModuleEndAddress(uint32 num __attribute__((unused)))
 {
-  return getKernelEndAddress();
+  assert(false);
 }
 
 uint32 ArchCommon::getVESAConsoleHeight()

--- a/arch/arm/common/source/ArchCommon.cpp
+++ b/arch/arm/common/source/ArchCommon.cpp
@@ -6,7 +6,7 @@
 #include "TextConsole.h"
 #include "FrameBufferConsole.h"
 #include "backtrace.h"
-#include "Stabs2DebugInfo.h"
+#include "SWEBDebugInfo.h"
 
 #define PHYSICAL_MEMORY_AVAILABLE 8*1024*1024
 
@@ -93,15 +93,10 @@ Stabs2DebugInfo const *kernel_debug_info = 0;
 
 void ArchCommon::initDebug()
 {
-  extern unsigned char stab_start_address_nr;
-  extern unsigned char stab_end_address_nr;
+  extern unsigned char swebdbg_start_address_nr;
+  extern unsigned char swebdbg_end_address_nr;
 
-  extern unsigned char stabstr_start_address_nr;
-
-  kernel_debug_info = new Stabs2DebugInfo((char const *)&stab_start_address_nr,
-                                          (char const *)&stab_end_address_nr,
-                                          (char const *)&stabstr_start_address_nr);
-
+  kernel_debug_info = new SWEBDebugInfo((const char *)&swebdbg_start_address_nr, (const char*)&swebdbg_end_address_nr);
 }
 
 extern "C" void halt()

--- a/arch/arm/integratorcp/CMakeLists.include
+++ b/arch/arm/integratorcp/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_ARM_ICP_KERNEL_CFLAGS -O0 -gstabs2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -march=armv5te -Wno-strict-aliasing -fshort-wchar ${NOPICFLAG})
+set(ARCH_ARM_ICP_KERNEL_CFLAGS -O0 -gdwarf-2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -march=armv5te -Wno-strict-aliasing -fshort-wchar ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -Wno-nonnull-compare -nostdinc++ -fno-rtti ${ARCH_ARM_ICP_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_ARM_ICP_KERNEL_CFLAGS})

--- a/arch/arm/integratorcp/CMakeLists.include
+++ b/arch/arm/integratorcp/CMakeLists.include
@@ -9,12 +9,18 @@ set(ARCH_LD_ARGUMENTS -Wl,--build-id=none -Wl,-z,max-page-size=0x1000 -nostdinc 
 set(KERNEL_LD_ARGUMENT ${ARCH_LD_ARGUMENTS} ${NOPIEFLAG})
 set(ARCH_APPEND_LD_ARGUMENTS -lgcc)
 
+set(ADD_LD_ARGUMENT -Wl,"${PROJECT_BINARY_DIR}/lib/debug_info.o")
+
+set(KERNEL_IMAGE_OBJCOPY
+COMMAND ${PROJECT_BINARY_DIR}/add-dbg ${PROJECT_BINARY_DIR}/kernel.x ${PROJECT_BINARY_DIR}/kernel.dbg
+COMMAND touch ${PROJECT_BINARY_DIR}/debug_info.c
+COMMAND ${CMAKE_C_COMPILER} -c ${PROJECT_BINARY_DIR}/debug_info.c -o ${PROJECT_BINARY_DIR}/lib/debug_info.o
+COMMAND "${OBJCOPY_EXECUTABLE}" --add-section .swebdbg="${PROJECT_BINARY_DIR}/kernel.dbg" --set-section-flags .swebdbg=load,data ${PROJECT_BINARY_DIR}/lib/debug_info.o
+COMMAND rm ${PROJECT_BINARY_DIR}/debug_info.c
+)
 
 MACRO(ARCH2OBJ ARCHOBJ_LIBNAME LIBRARY_NAME)
 ENDMACRO(ARCH2OBJ)
-
-
-set(KERNEL_IMAGE_OBJCOPY )
 
 # qemu: Run qemu in non debugging mode
 add_custom_target(qemu

--- a/arch/arm/integratorcp/CMakeLists.userspace
+++ b/arch/arm/integratorcp/CMakeLists.userspace
@@ -5,5 +5,5 @@ find_program(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gstabs2 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/arm/integratorcp/utils/kernel-ld-script.ld
+++ b/arch/arm/integratorcp/utils/kernel-ld-script.ld
@@ -23,6 +23,9 @@ SECTIONS
     ro_data_start_address = .;
     *(.rodata*)
     ro_data_end_address = .;
+    swebdbg_start_address_nr  = .;
+    *(.swebdbg)
+    swebdbg_end_address_nr  = .;
   }
   
   .data ALIGN(4096) : AT(LS_Phys + (LS_Data - LS_Code))

--- a/arch/arm/integratorcp/utils/kernel-ld-script.ld
+++ b/arch/arm/integratorcp/utils/kernel-ld-script.ld
@@ -42,27 +42,6 @@ SECTIONS
     *(COMMON)
     bss_end_address = .;
 
-  }
-
-  .stab : AT(LS_Phys + (LS_Stab - LS_Code))
-  {
-    LS_Stab = .;
-    stab_start_address_nr = .;
-    . = ALIGN(4096);
-    *(.stab)
-    . = ALIGN(4096);
-    stab_end_address_nr = .;
-  }
-  
-  .stabstr : AT(LS_Phys + (LS_Stabstr - LS_Code))
-  {
-    LS_Stabstr = .;
-    stabstr_start_address_nr = .;
-    . = ALIGN(4096);
-    *(.stabstr)
-    . = ALIGN(4096);
-    stabstr_end_address_nr = .;
-
     PROVIDE(kernel_end_address = .);
   }
   

--- a/arch/arm/rpi2/CMakeLists.include
+++ b/arch/arm/rpi2/CMakeLists.include
@@ -10,12 +10,18 @@ set(ARCH_LD_ARGUMENTS -Wl,--build-id=none -Wl,-z,max-page-size=0x1000 -nostdinc 
 set(KERNEL_LD_ARGUMENT ${ARCH_LD_ARGUMENTS} ${NOPIEFLAG})
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-lgcc)
 
+set(ADD_LD_ARGUMENT -Wl,"${PROJECT_BINARY_DIR}/lib/debug_info.o")
+
+set(KERNEL_IMAGE_OBJCOPY
+COMMAND ${PROJECT_BINARY_DIR}/add-dbg ${PROJECT_BINARY_DIR}/kernel.x ${PROJECT_BINARY_DIR}/kernel.dbg
+COMMAND touch ${PROJECT_BINARY_DIR}/debug_info.c
+COMMAND ${CMAKE_C_COMPILER} -c ${PROJECT_BINARY_DIR}/debug_info.c -o ${PROJECT_BINARY_DIR}/lib/debug_info.o
+COMMAND "${OBJCOPY_EXECUTABLE}" --add-section .swebdbg="${PROJECT_BINARY_DIR}/kernel.dbg" --set-section-flags .swebdbg=load,data ${PROJECT_BINARY_DIR}/lib/debug_info.o
+COMMAND rm ${PROJECT_BINARY_DIR}/debug_info.c
+)
 
 MACRO(ARCH2OBJ ARCHOBJ_LIBNAME LIBRARY_NAME)
 ENDMACRO(ARCH2OBJ)
-
-set(KERNEL_IMAGE_OBJCOPY )
-
 
 # sdcard: Create an sdcard for the raspberry pi
 add_custom_target(sdcard

--- a/arch/arm/rpi2/CMakeLists.include
+++ b/arch/arm/rpi2/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_RPI_KERNEL_CFLAGS -O0 -gstabs2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -Wno-strict-aliasing -march=armv6 -fshort-wchar ${NOPICFLAG})
+set(ARCH_RPI_KERNEL_CFLAGS -O0 -gdwarf-2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -Wno-strict-aliasing -march=armv6 -fshort-wchar ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -Wno-nonnull-compare -nostdinc++ -fno-rtti ${ARCH_RPI_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_RPI_KERNEL_CFLAGS})

--- a/arch/arm/rpi2/CMakeLists.include
+++ b/arch/arm/rpi2/CMakeLists.include
@@ -1,6 +1,6 @@
 set(KERNEL_BINARY kernel.x)
 
-set(ARCH_RPI_KERNEL_CFLAGS -O0 -gdwarf-2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -Wno-strict-aliasing -march=armv6 -fshort-wchar ${NOPICFLAG})
+set(ARCH_RPI_KERNEL_CFLAGS -O0 -gdwarf-2 -Wall -Wextra -Werror -Wno-error=format -nostdinc -nostdlib -nostartfiles -nodefaultlibs -fno-builtin -fno-exceptions -fno-stack-protector -ffreestanding -mapcs -marm -Wno-strict-aliasing -mcpu=cortex-a7 -fshort-wchar ${NOPICFLAG})
 
 set(KERNEL_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -std=gnu++17 -Wno-nonnull-compare -nostdinc++ -fno-rtti ${ARCH_RPI_KERNEL_CFLAGS})
 set(KERNEL_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   -std=gnu11 ${ARCH_RPI_KERNEL_CFLAGS})
@@ -39,16 +39,16 @@ add_custom_target(sdcardq
 
 # qemu: Run qemu in non debugging mode
 add_custom_target(qemu
-    COMMAND qemu-system-arm -kernel kernel.x -cpu arm1176 -m 1024 -M raspi2 -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp
-    COMMENT "Executing `qemu-system-arm -kernel kernel.x -cpu arm1176 -m 1024 -M raspi2 -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp`"
+    COMMAND qemu-system-arm -kernel kernel.x -cpu cortex-a7 -m 1024 -M raspi2b -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp
+    COMMENT "Executing `qemu-system-arm -kernel kernel.x -cpu cortex-a7 -m 1024 -M raspi2b -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp`"
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     COMMAND reset -I
     )
 
 # qemugdb: Run qemu in non debugging mode
 add_custom_target(qemugdb
-    COMMAND qemu-system-arm -kernel kernel.x -cpu arm1176 -m 512 -M raspi2 -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp -s -S
-    COMMENT "Executing `qemu-system-arm -kernel kernel.x -cpu arm1176 -m 512 -M raspi2 -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp -s -S`"
+    COMMAND qemu-system-arm -kernel kernel.x -cpu cortex-a7 -m 1024 -M raspi2b -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp -s -S
+    COMMENT "Executing `qemu-system-arm -kernel kernel.x -cpu cortex-a7 -m 1024 -M raspi2b -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial stdio -d guest_errors,unimp -s -S`"
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     COMMAND reset -I
     )

--- a/arch/arm/rpi2/CMakeLists.userspace
+++ b/arch/arm/rpi2/CMakeLists.userspace
@@ -5,5 +5,5 @@ find_program(CMAKE_C_COMPILER arm-none-eabi-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -g -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -mapcs -marm -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/arm/rpi2/source/ArchBoardSpecific.cpp
+++ b/arch/arm/rpi2/source/ArchBoardSpecific.cpp
@@ -81,7 +81,7 @@ void ArchBoardSpecific::frameBufferInit()
   assert(fbs.width == fbs.vwidth);
   assert(fbs.height == fbs.vheight);
   assert(fbs.size == (fbs.width * fbs.height * fbs.depth / 8));
-  framebuffer = (fbs.pointer & ~0xC0000000) + 0xC0000000;
+  framebuffer = fbs.pointer | IDENT_MAPPING_START;
 }
 
 void ArchBoardSpecific::onIdle()

--- a/arch/arm/rpi2/utils/kernel-ld-script.ld
+++ b/arch/arm/rpi2/utils/kernel-ld-script.ld
@@ -23,6 +23,9 @@ SECTIONS
     ro_data_start_address = .;
     *(.rodata*)
     ro_data_end_address = .;
+    swebdbg_start_address_nr  = .;
+    *(.swebdbg)
+    swebdbg_end_address_nr  = .;
   }
   
   .data ALIGN(4096) : AT(LS_Phys + (LS_Data - LS_Code))

--- a/arch/arm/rpi2/utils/kernel-ld-script.ld
+++ b/arch/arm/rpi2/utils/kernel-ld-script.ld
@@ -42,27 +42,6 @@ SECTIONS
     *(COMMON)
     bss_end_address = .;
 
-  }
-
-  .stab : AT(LS_Phys + (LS_Stab - LS_Code))
-  {
-    LS_Stab = .;
-    stab_start_address_nr = .;
-    . = ALIGN(4096);
-    *(.stab)
-    . = ALIGN(4096);
-    stab_end_address_nr = .;
-  }
-  
-  .stabstr : AT(LS_Phys + (LS_Stabstr - LS_Code))
-  {
-    LS_Stabstr = .;
-    stabstr_start_address_nr = .;
-    . = ALIGN(4096);
-    *(.stabstr)
-    . = ALIGN(4096);
-    stabstr_end_address_nr = .;
-
     PROVIDE(kernel_end_address = .);
   }
   

--- a/arch/armv8/common/source/ArchCommon.cpp
+++ b/arch/armv8/common/source/ArchCommon.cpp
@@ -8,8 +8,6 @@
 #include "backtrace.h"
 #include "SWEBDebugInfo.h"
 
-#define PHYSICAL_MEMORY_AVAILABLE 8*1024*1024
-
 extern void* kernel_end_address;
 
 pointer ArchCommon::getKernelEndAddress()

--- a/arch/armv8/common/source/ArchCommon.cpp
+++ b/arch/armv8/common/source/ArchCommon.cpp
@@ -22,7 +22,7 @@ pointer ArchCommon::getFreeKernelMemoryStart()
 
 pointer ArchCommon::getFreeKernelMemoryEnd()
 {
-   return (pointer)getModuleEndAddress(0);
+   return (pointer)&kernel_end_address;
 }
 
 
@@ -33,17 +33,17 @@ size_t ArchCommon::haveVESAConsole(size_t is_paging_set_up __attribute__((unused
 
 size_t ArchCommon::getNumModules(size_t is_paging_set_up __attribute__((unused)))
 {
-  return 1;
+  return 0;
 }
 
-size_t ArchCommon::getModuleStartAddress(size_t num __attribute__((unused)), size_t is_paging_set_up __attribute__((unused)))
+size_t ArchCommon::getModuleStartAddress(size_t num __attribute__((unused)))
 {
-  return LINK_BASE;
+  assert(false);
 }
 
-size_t ArchCommon::getModuleEndAddress(size_t num __attribute__((unused)), size_t is_paging_set_up __attribute__((unused)))
+size_t ArchCommon::getModuleEndAddress(size_t num __attribute__((unused)))
 {
-  return getKernelEndAddress();
+  assert(false);
 }
 
 size_t ArchCommon::getVESAConsoleHeight()

--- a/arch/armv8/rpi3/CMakeLists.include
+++ b/arch/armv8/rpi3/CMakeLists.include
@@ -51,16 +51,16 @@ add_custom_target(sdcardq
   )
 
 add_custom_target(qemu
-  COMMAND qemu-system-aarch64 -M raspi3 -cpu cortex-a53 -m 1024 -drive file=${HDD_IMAGE},if=sd -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp
-  COMMENT "Executing `qemu-system-aarch64 -M raspi3 -cpu cortex-a53 -m 1024 -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp`"
+  COMMAND qemu-system-aarch64 -M raspi3b -cpu cortex-a53 -m 1024 -drive file=${HDD_IMAGE},if=sd -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp
+  COMMENT "Executing `qemu-system-aarch64 -M raspi3b -cpu cortex-a53 -m 1024 -drive file=${HDD_IMAGE},if=sd -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp`"
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   COMMAND reset -I
   )
 
 # qemugdb: Run qemu in non debugging mode
 add_custom_target(qemugdb
-  COMMAND qemu-system-aarch64 -M raspi3 -cpu cortex-a53 -m 1024 -drive file=${HDD_IMAGE},if=sd -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp -s -S
-  COMMENT "Executing `qemu-system-aarch64 -M raspi3 -cpu cortex-a53 -m 1024 -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp -s -S`"
+  COMMAND qemu-system-aarch64 -M raspi3b -cpu cortex-a53 -m 1024 -drive file=${HDD_IMAGE},if=sd -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp -s -S
+  COMMENT "Executing `qemu-system-aarch64 -M raspi3b -cpu cortex-a53 -m 1024 -drive file=${HDD_IMAGE},if=sd -no-reboot -kernel kernel.x -serial stdio -d guest_errors,unimp -s -S`"
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   COMMAND reset -I
   )

--- a/arch/armv8/rpi3/CMakeLists.userspace
+++ b/arch/armv8/rpi3/CMakeLists.userspace
@@ -5,5 +5,5 @@ find_program(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 
 set(ARCH_APPEND_LD_ARGUMENTS -Wl,-no-whole-archive -Wl,-lgcc)
 
-set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror  -std=gnu11 -g -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
+set(ARCH_USERSPACE_COMPILE_OPTIONS -Wall -Werror  -std=gnu11 -gdwarf-4 -O0 -static -nostdinc -fno-builtin -nostdlib -fno-stack-protector -fno-common -Werror=implicit-function-declaration -Wno-error=unused-variable -fno-stack-clash-protection)
 set(ARCH_USERSPACE_LINKER_OPTIONS -static)

--- a/arch/armv8/rpi3/utils/kernel-ld-script.ld
+++ b/arch/armv8/rpi3/utils/kernel-ld-script.ld
@@ -47,27 +47,6 @@ SECTIONS
         . = ALIGN(4096);
     bss_end_address = .;
 
-  }
-
-  .stab : AT(LS_Phys + (LS_Stab - LS_Code))
-  {
-    LS_Stab = .;
-    stab_start_address_nr = .;
-    . = ALIGN(4096);
-    *(.stab)
-    . = ALIGN(4096);
-    stab_end_address_nr = .;
-  }
-  
-  .stabstr : AT(LS_Phys + (LS_Stabstr - LS_Code))
-  {
-    LS_Stabstr = .;
-    stabstr_start_address_nr = .;
-    . = ALIGN(4096);
-    *(.stabstr)
-    . = ALIGN(4096);
-    stabstr_end_address_nr = .;
-
     PROVIDE(kernel_end_address = .);
   }
   

--- a/common/include/util/kstring.h
+++ b/common/include/util/kstring.h
@@ -3,7 +3,6 @@
 #define STRING_SAVE
 
 #include "types.h"
-#include "paging-definitions.h"
 
 /**
  * Convert a define to a string.

--- a/common/source/util/SWEBDebugInfo.cpp
+++ b/common/source/util/SWEBDebugInfo.cpp
@@ -24,7 +24,7 @@ struct LineHeader {
 
 
 SWEBDebugInfo::SWEBDebugInfo(char const *sweb_start, char const *sweb_end) : Stabs2DebugInfo(sweb_start, sweb_end, 0) {
-  if (sweb_start != 0 && sweb_end != 0)
+  if (sweb_start && sweb_end && sweb_start != sweb_end)
     initialiseSymbolTable();
 }
 

--- a/utils/travis_test.sh
+++ b/utils/travis_test.sh
@@ -24,7 +24,7 @@ fi
 if [[ "$1" == "arm_rpi2" ]]; 
 then
     exit 0 # not supported in the travis qemu
-    qemu-system-arm -kernel kernel.x -cpu arm1176 -m 512 -M raspi2 -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial file:/tmp/out.log -d guest_errors,unimp -monitor pipe:/tmp/qemu -nographic -display none > /dev/null 2> /dev/null &
+    qemu-system-arm -kernel kernel.x -cpu cortex-a7 -m 1024 -M raspi2b -no-reboot -drive if=sd,file=${HDD_IMAGE} -serial file:/tmp/out.log -d guest_errors,unimp -monitor pipe:/tmp/qemu -nographic -display none > /dev/null 2> /dev/null &
     sleep 2
 fi
 if [[ "$1" == "arm_icp" ]]; 

--- a/utils/travis_test.sh
+++ b/utils/travis_test.sh
@@ -33,8 +33,8 @@ then
 fi
 if [[ "$1" == "armv8_rpi3" ]];
 then
-    if [[ $(qemu-system-aarch64 -machine help | grep raspi3 | wc -l) != "0" ]]; then
-        qemu-system-aarch64 -M raspi3 -cpu cortex-a53 -m 1024 -drive file=SWEB-flat.vmdk,if=sd,format=raw -no-reboot -kernel kernel.x -serial file:/tmp/out.log -d guest_errors,unimp -monitor pipe:/tmp/qemu -nographic -display none  > /dev/null 2> /dev/null  &
+    if [[ $(qemu-system-aarch64 -machine help | grep raspi3b | wc -l) != "0" ]]; then
+        qemu-system-aarch64 -M raspi3b -cpu cortex-a53 -m 1024 -drive file=SWEB-flat.vmdk,if=sd,format=raw -no-reboot -kernel kernel.x -serial file:/tmp/out.log -d guest_errors,unimp -monitor pipe:/tmp/qemu -nographic -display none  > /dev/null 2> /dev/null  &
         sleep 10
     else
         echo "QEMU version is too old to support the raspberry pi 3"


### PR DESCRIPTION
This is a follow-up to #305 fixing ARM targets.

- `arm_icp`: boots, can load debug info, but stacktraces do not contain a lot of info.
- `arm_rpi2`: boots, stuck at initializing interrupts. before changing cpu target this would not boot for me at all.
- `armv8_rpi3`: boots, debug info still ok. (keyboard still only works when focusing terminal)