### PR TITLE
Enable PL011 UART peripheral on rpi2

### DIFF
--- a/arch/arm/rpi2/include/board_constants.h
+++ b/arch/arm/rpi2/include/board_constants.h
@@ -1,7 +1,11 @@
 #pragma once
 
+// https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
+
+// BCM2835 PL011 UART
 #define SERIAL_BASE 0x86001000
 #define SERIAL_FLAG_REGISTER 0x18
+#define SERIAL_CONTROL_REGISTER 0x30
 #define SERIAL_BUFFER_FULL (1 << 5)
 
 #define PIC_BASE 0x9000B200

--- a/arch/arm/rpi2/source/debug_bochs.cpp
+++ b/arch/arm/rpi2/source/debug_bochs.cpp
@@ -3,8 +3,20 @@
 #include "KeyboardManager.h"
 #include "board_constants.h"
 
+static bool pl011_uart_enabled = false;
+
 void writeChar2Bochs( char char2Write )
 {
+  if (unlikely(!pl011_uart_enabled)) {
+    // Enable BCM2835 PL011 UART
+    *((volatile unsigned long*)(SERIAL_BASE + SERIAL_CONTROL_REGISTER)) |= 
+      (1 << 0) | // UARTEN uart enable bit
+      (1 << 8) | // TXE transmit enable bit
+      (1 << 9);  // RXE receive enable bit
+
+      pl011_uart_enabled = true;
+  }
+
   /* Wait until the serial buffer is empty */
   while (*(volatile unsigned long*)(SERIAL_BASE + SERIAL_FLAG_REGISTER)
                                      & (SERIAL_BUFFER_FULL));


### PR DESCRIPTION
Could be done in a better location during initial boot, but this fixes the debug output on rpi2.