### PR TITLE
fixed a wrong static_assert

### DIFF
--- a/arch/x86/32/include/paging-definitions.h
+++ b/arch/x86/32/include/paging-definitions.h
@@ -80,5 +80,5 @@ typedef struct
   size_t page_ppn                  :20;
 } __attribute__((__packed__)) PageTableEntry;
 
-static_assert(sizeof(PageDirPageEntry) == 4, "PageTableEntry is not 32 bit");
+static_assert(sizeof(PageTableEntry) == 4, "PageTableEntry is not 32 bit");
 


### PR DESCRIPTION
Fixed a static assert in the 32bit paging definitions, which was probably a typo in 79a484183f3d3c9664ed523a2b16aa0e874ff298