### PR TITLE
Silenced unused variable warning

### DIFF
--- a/common/source/fs/minixfs/MinixFSInode.cpp
+++ b/common/source/fs/minixfs/MinixFSInode.cpp
@@ -90,7 +90,7 @@ int32 MinixFSInode::writeData(uint32 offset, uint32 size, const char *buffer)
   if (num_zones*ZONE_SIZE < size) return -1;
 
   uint32 last_used_zone = i_size_ / ZONE_SIZE;
-  uint32 last_zone = last_used_zone;
+  [[maybe_unused]] uint32 last_zone = last_used_zone;
   if ((size + offset) > i_size_)
   {
     uint32 num_new_zones = (size + offset - i_size_) / ZONE_SIZE + 1;


### PR DESCRIPTION
Silenced unused variable warning (escalated to an error by `-Werror`) in a clean build:

```cpp
[build] ./sweb/common/source/fs/minixfs/MinixFSInode.cpp: In member function ‘virtual int32 MinixFSInode::writeData(uint32, uint32, const char*)’:
[build] ./sweb/common/source/fs/minixfs/MinixFSInode.cpp:93:10: error: variable ‘last_zone’ set but not used [-Werror=unused-but-set-variable=]
[build]    93 |   uint32 last_zone = last_used_zone;
[build]       |          ^~~~~~~~~
[build] cc1plus: all warnings being treated as errors
```